### PR TITLE
easy fix for the parity for 7292

### DIFF
--- a/src/IsEven.java
+++ b/src/IsEven.java
@@ -21879,6 +21879,9 @@ public class IsEven {
 		if(7291 == num){
 			even = false;
 		}
+		if(7292 == num){
+			even = true;
+		}
 		input.close();
 		System.out.println(num + " is even: " + even);
 	}


### PR DESCRIPTION
when i input 7292, the output of the program is:
```
7292 is even: false
```
this pr aims to fix that

when i reference chatgpt:
![image](https://github.com/user-attachments/assets/b91c34d1-6f33-4f22-9caf-a9b86f7b4be9)
so clearly, 7292 is an even number.  another easy way to check is by running it through the geeks for geeks tutorial and checking it that way:
https://www.geeksforgeeks.org/program-to-find-parity/
you'll have to make a login for that though.  this program also uses a somewhat unintuitive formula, but i've found that it agrees with all of the test cases i ran it through (integers 1-7291)

let me know if you have any questions!